### PR TITLE
raw_data filenames should be unique in the scope of projects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,10 +27,10 @@ gem 'rubyzip'
 gem 'sass-rails'
 gem 'simple_form'
 gem 'slim-rails'
-gem 'sprockets-rails', :require => 'sprockets/railtie'
+gem 'sprockets-rails', require: 'sprockets/railtie'
 gem 'swagger-docs'
 gem 'therubyracer'
-gem 'turbolinks'
+gem 'turbolinks', git: 'https://github.com/rails/turbolinks.git'
 gem 'uglifier'
 
 group :doc do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,13 @@ GIT
       responders
       warden (~> 1.2.3)
 
+GIT
+  remote: https://github.com/rails/turbolinks.git
+  revision: 37a7c296232d20a61bd1946f600da7f2009189db
+  specs:
+    turbolinks (3.0.0)
+      coffee-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -52,7 +59,7 @@ GEM
     addressable (2.4.0)
     arel (7.0.0)
     ast (2.2.0)
-    autoprefixer-rails (6.3.6.1)
+    autoprefixer-rails (6.3.6.2)
       execjs
     awesome_print (1.6.1)
     axiom-types (0.1.1)
@@ -353,8 +360,6 @@ GEM
     thread_safe (0.3.5)
     tilt (2.0.4)
     tins (1.10.2)
-    turbolinks (2.5.3)
-      coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (3.0.0)
@@ -438,7 +443,7 @@ DEPENDENCIES
   sqlite3
   swagger-docs
   therubyracer
-  turbolinks
+  turbolinks!
   uglifier
   unicorn
   web-console

--- a/app/models/raw_datum.rb
+++ b/app/models/raw_datum.rb
@@ -11,8 +11,12 @@ class RawDatum < ApplicationRecord
 
   belongs_to :project
   has_attached_file :data
+  before_save :destroy_raw_datum_with_same_filename
 
   validates :project,
+    presence: true
+
+  validates :filename,
     presence: true
 
   validates :shape,
@@ -64,9 +68,10 @@ class RawDatum < ApplicationRecord
         raw_datum = RawDatum.new(
           project: project,
           shape: SHAPES.first,
+          filename: filename.force_encoding('utf-8'),
           data: File.open("#{temp_dir}/#{extraction_filename.force_encoding('utf-8')}")
         )
-        batch_result = process_result(raw_datum, extraction_filename, batch_result)
+        batch_result = process_result(raw_datum, filename, batch_result)
       end
     end
     batch_result
@@ -79,8 +84,12 @@ class RawDatum < ApplicationRecord
     return filename, extraction_filename
   end
 
+  def self.encode_filename(filename)
+    ActiveSupport::Multibyte::Unicode.normalize(filename)
+  end
+
   def self.process_result(raw_datum, filename, batch_result)
-    encoded_filename = ActiveSupport::Multibyte::Unicode.normalize(filename)
+    encoded_filename = encode_filename(filename)
     if raw_datum.save
       batch_result[:success] << encoded_filename
     else
@@ -96,6 +105,7 @@ class RawDatum < ApplicationRecord
       raw_datum = RawDatum.new(
         project: project,
         shape: SHAPES.first,
+        filename: filename.force_encoding('utf-8'),
         data: File.open(datum[:path])
       )
       raw_datum.data_file_name = filename
@@ -106,5 +116,14 @@ class RawDatum < ApplicationRecord
       end
     end
     batch_result
+  end
+
+  private
+
+  def destroy_raw_datum_with_same_filename
+    RawDatum.where(
+      project: self.project,
+      filename: self.filename
+    ).destroy_all
   end
 end

--- a/db/migrate/20160531151835_add_filename_to_raw_data.rb
+++ b/db/migrate/20160531151835_add_filename_to_raw_data.rb
@@ -1,0 +1,5 @@
+class AddFilenameToRawData < ActiveRecord::Migration[5.0]
+  def change
+    add_column :raw_data, :filename, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160531081559) do
+ActiveRecord::Schema.define(version: 20160531151835) do
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer  "priority",   default: 0, null: false
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 20160531081559) do
     t.integer  "data_file_size"
     t.datetime "data_updated_at"
     t.integer  "project_id"
+    t.string   "filename"
     t.index ["project_id"], name: "index_raw_data_on_project_id"
   end
 

--- a/spec/factories/raw_data.rb
+++ b/spec/factories/raw_data.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :raw_datum do
     shape 'text'
+    filename 'file.md'
     data File.new(Rails.root + 'spec/fixtures/text/lorem.txt')
     project { FactoryGirl.create(:project) }
   end

--- a/spec/models/raw_datum_spec.rb
+++ b/spec/models/raw_datum_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe RawDatum, :type => :model do
                                           file_path
       expect(batch_result).to eq(
         {
-          success: ['root_file.md', 'subdir/file.md'], # be aware that the slash is U+2215
+          success: ['root_file.md', 'subdir/file.md'],
           error: []
         }
       )
@@ -157,8 +157,8 @@ RSpec.describe RawDatum, :type => :model do
                                           file_path
       expect(batch_result).to eq(
         {
-          success: ['valid1.md', 'subdir/valid2.md'], # be aware that the slash is U+2215
-          error: ['invalid1.bin', 'subdir/invalid2.bin'] # be aware that the slash is U+2215
+          success: ['valid1.md', 'subdir/valid2.md'],
+          error: ['invalid1.bin', 'subdir/invalid2.bin']
         }
       )
       expect(RawDatum.all.count).to eq(2)

--- a/spec/models/raw_datum_spec.rb
+++ b/spec/models/raw_datum_spec.rb
@@ -9,6 +9,61 @@ RSpec.describe RawDatum, :type => :model do
     expect(@raw_datum).to be_valid
   end
 
+  describe 'filename' do
+    it 'should not be nil' do
+      @raw_datum.filename = nil
+      expect(@raw_datum).to be_invalid
+    end
+
+    it 'should not be empty string' do
+      @raw_datum.filename = ''
+      expect(@raw_datum).to be_invalid
+    end
+
+    it 'should not consist only of whitespace' do
+      @raw_datum.filename = '  '
+      expect(@raw_datum).to be_invalid
+    end
+
+    it 'can be a valid filename' do
+      @raw_datum.filename = 'file.md'
+      expect(@raw_datum).to be_valid
+    end
+
+    it 'can be a path with directories' do
+      @raw_datum.filename = 'directory/file.md'
+      expect(@raw_datum).to be_valid
+    end
+
+    it 'should be unique in the scope of projects and override existing raw_data' do
+      expect(RawDatum.all.size).to eq(0)
+      @raw_datum.filename = 'file1.md'
+      @raw_datum.save!
+      expect(RawDatum.all.size).to eq(1)
+      another_raw_datum = FactoryGirl.build(:raw_datum,
+        filename: 'file2.md',
+        project: @raw_datum.project
+      )
+      another_raw_datum.save!
+      expect(RawDatum.all.size).to eq(2)
+    end
+
+    it 'should be unique in the scope of projects and override existing raw_data' do
+      expect(RawDatum.all.size).to eq(0)
+      @raw_datum.filename = 'file1.md'
+      @raw_datum.save!
+      old_id = @raw_datum.id
+      expect(RawDatum.all.size).to eq(1)
+      another_raw_datum = FactoryGirl.build(:raw_datum,
+        filename: 'file1.md',
+        project: @raw_datum.project
+      )
+      another_raw_datum.save!
+      expect(RawDatum.all.size).to eq(1)
+      expect(old_id != another_raw_datum.id)
+    end
+  end
+
   describe 'shape' do
     it 'should not be nil' do
       @raw_datum.shape = nil
@@ -88,7 +143,7 @@ RSpec.describe RawDatum, :type => :model do
                                           file_path
       expect(batch_result).to eq(
         {
-          success: ['root_file.md', 'subdir∕file.md'], # be aware that the slash is U+2215
+          success: ['root_file.md', 'subdir/file.md'], # be aware that the slash is U+2215
           error: []
         }
       )
@@ -102,8 +157,8 @@ RSpec.describe RawDatum, :type => :model do
                                           file_path
       expect(batch_result).to eq(
         {
-          success: ['valid1.md', 'subdir∕valid2.md'], # be aware that the slash is U+2215
-          error: ['invalid1.bin', 'subdir∕invalid2.bin'] # be aware that the slash is U+2215
+          success: ['valid1.md', 'subdir/valid2.md'], # be aware that the slash is U+2215
+          error: ['invalid1.bin', 'subdir/invalid2.bin'] # be aware that the slash is U+2215
         }
       )
       expect(RawDatum.all.count).to eq(2)


### PR DESCRIPTION
Therefore raw_data gets a filename as a seperate attribute ~~with `uniqueness: { scope: :project }`~~.
Create a before_save which checks for filename collisions and deletes colliding raw_data.
