### PR TITLE
fix `Too many open files - Maximum file multiparts in content reached` when uploading a lot of raw data

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -5,4 +5,6 @@ require ::File.expand_path('../config/environment', __FILE__)
 # Action Cable requires that all classes are loaded in advance
 Rails.application.eager_load!
 
+Rack::Utils.multipart_part_limit = 0
+
 run Rails.application


### PR DESCRIPTION
```
Puma caught this error: Too many open files - Maximum file multiparts in content reached (Rack::Multipart::MultipartPartLimitError)
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/multipart/parser.rb:159:in `check_open_files'
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/multipart/parser.rb:143:in `on_mime_head'
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/multipart/parser.rb:258:in `handle_mime_head'
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/multipart/parser.rb:211:in `block in run_parser'
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/multipart/parser.rb:204:in `loop'
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/multipart/parser.rb:204:in `run_parser'
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/multipart/parser.rb:187:in `on_read'
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/multipart/parser.rb:72:in `block in parse'
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/multipart/parser.rb:70:in `loop'
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/multipart/parser.rb:70:in `parse'
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/multipart.rb:52:in `extract_multipart'
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/request.rb:472:in `parse_multipart'
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/request.rb:335:in `POST'
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/method_override.rb:39:in `method_override_param'
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/method_override.rb:27:in `method_override'
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/method_override.rb:15:in `call'
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/runtime.rb:22:in `call'
/home/arik/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0/lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
/home/arik/.rvm/gems/ruby-2.3.1/gems/actionpack-5.0.0/lib/action_dispatch/middleware/executor.rb:12:in `call'
/home/arik/.rvm/gems/ruby-2.3.1/gems/actionpack-5.0.0/lib/action_dispatch/middleware/static.rb:136:in `call'
/home/arik/.rvm/gems/ruby-2.3.1/gems/rack-2.0.1/lib/rack/sendfile.rb:111:in `call'
/home/arik/.rvm/gems/ruby-2.3.1/gems/railties-5.0.0/lib/rails/engine.rb:522:in `call'
/home/arik/.rvm/gems/ruby-2.3.1/gems/puma-3.6.0/lib/puma/configuration.rb:225:in `call'
/home/arik/.rvm/gems/ruby-2.3.1/gems/puma-3.6.0/lib/puma/server.rb:578:in `handle_request'
/home/arik/.rvm/gems/ruby-2.3.1/gems/puma-3.6.0/lib/puma/server.rb:415:in `process_client'
/home/arik/.rvm/gems/ruby-2.3.1/gems/puma-3.6.0/lib/puma/server.rb:275:in `block in run'
/home/arik/.rvm/gems/ruby-2.3.1/gems/puma-3.6.0/lib/puma/thread_pool.rb:116:in `block in spawn_thread'
```
