### PR TITLE
fix localization of annotation_documents' blank slate

### DIFF
--- a/app/views/shared/blank_slates/_annotation_documents.slim
+++ b/app/views/shared/blank_slates/_annotation_documents.slim
@@ -1,11 +1,11 @@
 .jumbotron
   h1.display-3
-    = t('annotation-documents.blank-slate.index.title')
+    = t('annotation-documents.blank-slate.admin.index.title')
   p.lead
-    = t('annotation-documents.blank-slate.index.text')
+    = t('annotation-documents.blank-slate.admin.index.text')
   hr.m-y-2
   = render 'shared/button',
-           label: t('annotation-documents.blank-slate.index.button-label'),
+           label: t('annotation-documents.blank-slate.admin.index.button-label'),
            icon: 'plus',
            type: 'submit',
            href: project_iterate_path(project),


### PR DESCRIPTION
<img width="781" alt="bildschirmfoto 2016-12-05 um 09 53 10" src="https://cloud.githubusercontent.com/assets/8058264/20878709/af328c5a-bad0-11e6-8a80-ddecd5d667bc.png">
