### PR TITLE
make API compatible for async annotation documents

### DIFF
--- a/app/controllers/api/v1/annotation_documents_controller.rb
+++ b/app/controllers/api/v1/annotation_documents_controller.rb
@@ -152,17 +152,17 @@ module API
 
       # POST /api/v1/annotation_documents
       def create
-        ActiveRecord::Base.transaction do
-          annotation_documents = []
-          annotation_documents_params.each do |ad_params|
-            @annotation_document = AnnotationDocument.new(ad_params)
-            @annotation_document.save!
+        ActionController::Parameters.permit_all_parameters = true
+        annotation_documents = []
+        annotation_documents_params.each do |ad_params|
+          @annotation_document = AnnotationDocument.new(ad_params)
+          if @annotation_document.save
             annotation_documents << @annotation_document.relevant_attributes
           end
-          annotation_documents = annotation_documents.first if annotation_documents.count == 1
-          render status: 200,
-                 json: annotation_documents
         end
+        annotation_documents = annotation_documents.first if annotation_documents.count == 1
+        render status: 200,
+               json: annotation_documents
       rescue ArgumentError
         return_parameter_type_mismatch
       rescue


### PR DESCRIPTION
- [x] permit all parameters for annotation documents creation
- [x] do not use a transaction for bulk creation in order to save valid documents