### PR TITLE
introduce get param `synchronous_request` in order to receive annotation documents synchronously

### DIFF
--- a/app/assets/javascripts/annotation_document_manager.coffee
+++ b/app/assets/javascripts/annotation_document_manager.coffee
@@ -72,7 +72,6 @@ class AnnotationDocumentManager
   initialAnnotationDocumentPreloading: ->
     documentId = $('.interfaces-staging').data('annotation-document-id')
     documentId = this.documentIdFromUrl() unless documentId
-
     this.loadAnnotationDocumentWithId(documentId) if documentId
     this.loadAnnotationDocuments() unless documentId
 

--- a/app/assets/javascripts/annotation_lifecycle.coffee
+++ b/app/assets/javascripts/annotation_lifecycle.coffee
@@ -26,7 +26,9 @@ class AnnotationLifecycle
     dalphiBaseUrl = $('.interfaces-staging').data('dalphi-base-url')
     projectId = $('.interfaces-staging').data('project-id')
     synchronousRequest = $('.interfaces-staging').data('synchronous-request')
-    this.annotationDocumentManager = new window.AnnotationDocumentManager(dalphiBaseUrl, projectId, synchronousRequest)
+    this.annotationDocumentManager = new window.AnnotationDocumentManager(
+      dalphiBaseUrl, projectId, synchronousRequest
+    )
 
     $.each($('.template', '.interfaces-staging'), (index, template) ->
       interfaceType = $(template).data('interface-type')

--- a/app/assets/javascripts/annotation_lifecycle.coffee
+++ b/app/assets/javascripts/annotation_lifecycle.coffee
@@ -25,7 +25,8 @@ class AnnotationLifecycle
   init: ->
     dalphiBaseUrl = $('.interfaces-staging').data('dalphi-base-url')
     projectId = $('.interfaces-staging').data('project-id')
-    this.annotationDocumentManager = new window.AnnotationDocumentManager(dalphiBaseUrl, projectId)
+    synchronousRequest = $('.interfaces-staging').data('synchronous-request')
+    this.annotationDocumentManager = new window.AnnotationDocumentManager(dalphiBaseUrl, projectId, synchronousRequest)
 
     $.each($('.template', '.interfaces-staging'), (index, template) ->
       interfaceType = $(template).data('interface-type')

--- a/app/views/annotation_documents/index.slim
+++ b/app/views/annotation_documents/index.slim
@@ -43,7 +43,7 @@
                             type: 'submit',
                             href: project_merge_path(@project),
                             method: 'post' },
-                          { label: t('annotation-documents.blank-slate.generate-annotation-documents'),
+                          { label: t('annotation-documents.blank-slate.admin.index.button-label'),
                             icon: 'plus',
                             type: 'submit',
                             href: project_iterate_path(@project),

--- a/app/views/annotations/annotate.slim
+++ b/app/views/annotations/annotate.slim
@@ -5,7 +5,8 @@
 ruby:
   data_hash = {
     dalphi_base_url: request.base_url,
-    project_id: @project.id
+    project_id: @project.id,
+    synchronous_request: params[:synchronous_request] || false
   }
   data_hash[:annotation_document_id] = @annotation_document.id if @annotation_document
 


### PR DESCRIPTION
Capybara with Poltergeist/PhantomJS is currently not able to receive annotation documents asynchronously due to some race conditions (see #264).
This behaviour applies to teaspoon as well (but was not further investigated).

Until the issue #264 is fixed it is necessary to receive annotation documents synchronously for the above clients.